### PR TITLE
feature/non-composer autoloading fallback

### DIFF
--- a/ll-voordemensen.php
+++ b/ll-voordemensen.php
@@ -26,6 +26,10 @@ add_action(
 		if ( file_exists( $autoload_file ) ) {
 			require_once $autoload_file;
 		} else {
+			/**
+			 * Autoload using spl_autoload_register
+			 * @see https://www.php.net/manual/en/language.oop5.autoload.php#120258
+			 */
 			$autoload_dir = LL_VDM_PLUGIN_PATH . 'app' . DIRECTORY_SEPARATOR;
 			spl_autoload_register(
 				function ( string $class ) use ( $autoload_dir ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->

## Description
<!--- Describe your changes in detail -->
Allow the plugin to work without composer autoloading.
Uses the `spl_autoload_register` function to load the classes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deleting the `vendor` folder and looking if the plugin works.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
