### PR TITLE
add option to prevent importing different vdm object

### DIFF
--- a/app/Sync/EventTypesSync.php
+++ b/app/Sync/EventTypesSync.php
@@ -37,6 +37,10 @@ class EventTypesSync extends BaseSync {
 			$event_type_id = $event_type->get_id();
 		}
 
+		if ( ! apply_filters( 'll_vdm_should_insert_event_type', true, $event_type_id, $api_event_type ) ) {
+			return 0;
+		}
+
 		do_action( 'll_vdm_before_insert_event_type', $event_type_id, $api_event_type );
 
 		$term_data = array(

--- a/app/Sync/LocationsSync.php
+++ b/app/Sync/LocationsSync.php
@@ -36,6 +36,10 @@ class LocationsSync extends BaseSync {
 			$location_id = $location->get_id();
 		}
 
+		if ( ! apply_filters( 'll_vdm_should_insert_location', true, $location_id, $api_location ) ) {
+			return 0;
+		}
+
 		do_action( 'll_vdm_before_insert_location', $location_id, $api_location );
 
 		$term_data = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
https://app.asana.com/0/1195088574671066/1200283174690400/f
https://app.asana.com/0/1195088574671066/1200284259553030/f

## Description
<!--- Describe your changes in detail -->
Events with status `arch` should not be imported.
Also added option to modify if an object should be imported

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
