### PR TITLE
Feature Addition: Custom Domain Support for Ticket Frontends

### DIFF
--- a/app/Admin/Settings/General/Fields/DomainName.php
+++ b/app/Admin/Settings/General/Fields/DomainName.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace LevelLevel\VoorDeMensen\Admin\Settings\General\Fields;
+
+class DomainName extends BaseField {
+
+	protected const NAME = 'domain_name';
+
+	public function get_name(): string {
+		return self::PREFIX . self::NAME;
+	}
+
+	public function get_label(): string {
+		return __( 'Domain name', 'll-vdm' );
+	}
+
+	public function get_description(): string {
+		return __( 'If VoordeMensen is running on a private (sub)domain, enter it here - otherwise leave to the standard tickets.voordemensen.nl', 'll-vdm' );
+	}
+
+	public function get_value(): ?string {
+		$default = $this->get_default_value();
+		$value   = (string) get_option( $this->get_name(), $default );
+		if ( empty( $value ) ) {
+			return $default;
+		}
+		return $value;
+	}
+
+	/**
+	 * Get default value
+	 *
+	 * @return null
+	 */
+	protected function get_default_value() {
+		return 'tickets.voordemensen.nl';
+	}
+
+	public function render_field(): void {
+		$setting = $this->get_value();
+		?>
+
+		<p><label for="<?php echo esc_attr( $this->get_name() ); ?>"><?php echo esc_html( $this->get_description() ); ?></label></p>
+
+		<input type="text" id="<?php echo esc_attr( $this->get_name() ); ?>" name="<?php echo esc_attr( $this->get_name() ); ?>" class="regular-text" value="<?php echo isset( $setting ) ? esc_attr( $setting ) : ''; ?>">
+
+		<?php
+	}
+}

--- a/app/Admin/Settings/General/Fields/DomainName.php
+++ b/app/Admin/Settings/General/Fields/DomainName.php
@@ -30,7 +30,7 @@ class DomainName extends BaseField {
 	/**
 	 * Get default value
 	 *
-	 * @return null
+	 * @return string The default URL.
 	 */
 	protected function get_default_value() {
 		return 'tickets.voordemensen.nl';

--- a/app/Admin/Settings/General/Fields/DomainName.php
+++ b/app/Admin/Settings/General/Fields/DomainName.php
@@ -15,7 +15,7 @@ class DomainName extends BaseField {
 	}
 
 	public function get_description(): string {
-		return __( 'If VoordeMensen is running on a private (sub)domain, enter it here - otherwise leave to the standard tickets.voordemensen.nl', 'll-vdm' );
+		return __( 'If VoordeMensen is running on a private (sub)domain, enter it here. Otherwise keep it the default value of tickets.voordemensen.nl. Please note that your private (sub)domain needs to support https.', 'll-vdm' );
 	}
 
 	public function get_value(): ?string {

--- a/app/Admin/Settings/General/Settings.php
+++ b/app/Admin/Settings/General/Settings.php
@@ -10,8 +10,8 @@ use LevelLevel\VoorDeMensen\Admin\Settings\Menu;
 
 class Settings {
 	public const FIELDS = array(
-		ClientName::class,
 		DomainName::class,
+		ClientName::class,
 		PostTypes::class,
 		SyncEventsInterval::class,
 	);

--- a/app/Admin/Settings/General/Settings.php
+++ b/app/Admin/Settings/General/Settings.php
@@ -3,6 +3,7 @@
 namespace LevelLevel\VoorDeMensen\Admin\Settings\General;
 
 use LevelLevel\VoorDeMensen\Admin\Settings\General\Fields\ClientName;
+use LevelLevel\VoorDeMensen\Admin\Settings\General\Fields\DomainName;
 use LevelLevel\VoorDeMensen\Admin\Settings\General\Fields\PostTypes;
 use LevelLevel\VoorDeMensen\Admin\Settings\General\Fields\SyncEventsInterval;
 use LevelLevel\VoorDeMensen\Admin\Settings\Menu;
@@ -10,6 +11,7 @@ use LevelLevel\VoorDeMensen\Admin\Settings\Menu;
 class Settings {
 	public const FIELDS = array(
 		ClientName::class,
+		DomainName::class,
 		PostTypes::class,
 		SyncEventsInterval::class,
 	);

--- a/app/Assets.php
+++ b/app/Assets.php
@@ -4,6 +4,7 @@ namespace LevelLevel\VoorDeMensen;
 
 use LevelLevel\VoorDeMensen\Admin\Settings\Display\Fields\TicketSalesScreenType as TicketSalesScreenTypeSetting;
 use LevelLevel\VoorDeMensen\Admin\Settings\General\Fields\ClientName as ClientNameSetting;
+use LevelLevel\VoorDeMensen\Admin\Settings\General\Fields\DomainName as DomainNameSetting;
 use LevelLevel\VoorDeMensen\API\Client;
 
 class Assets {
@@ -85,14 +86,22 @@ class Assets {
 
 	public function enqueue_external_vdm_script(): void {
 		$client_name = ( new ClientNameSetting() )->get_value();
+		$domain_name = ( new DomainNameSetting() )->get_value();
+
 		if ( empty( $client_name ) ) {
 			return;
 		}
 
+		if ( empty( $domain_name ) ) {
+			$domain_name='tickets.voordemensen.nl';
+		}
+
+
+
 		$display_type = ( new TicketSalesScreenTypeSetting() )->get_value();
-		$src          = 'https://tickets.voordemensen.nl/' . rawurlencode( $client_name ) . '/event/vdm_loader.js';
+		$src          = 'https://' . rawurlencode ( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_loader.js';
 		if ( $display_type === 'side' ) {
-			$src = 'https://tickets.voordemensen.nl/' . rawurlencode( $client_name ) . '/event/vdm_sideloader.js';
+			$src = 'https://' . rawurlencode ( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_sideloader.js';
 		}
 
 		wp_enqueue_script( 'll_vdm_external_script', $src, array(), LL_VDM_PLUGIN_VERSION, true );

--- a/app/Assets.php
+++ b/app/Assets.php
@@ -97,9 +97,9 @@ class Assets {
 		}
 
 		$display_type = ( new TicketSalesScreenTypeSetting() )->get_value();
-		$src = 'https://' . rawurlencode($domain_name) . '/' . rawurlencode($client_name) . '/event/vdm_loader.js';
-		if ($display_type === 'side') {
-			$src = 'https://' . rawurlencode($domain_name) . '/' . rawurlencode($client_name) . '/event/vdm_sideloader.js';
+		$src          = 'https://' . rawurlencode( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_loader.js';
+		if ( $display_type === 'side' ) {
+			$src = 'https://' . rawurlencode( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_sideloader.js';
 		}
 		wp_enqueue_script( 'll_vdm_external_script', $src, array(), LL_VDM_PLUGIN_VERSION, true );
 	}

--- a/app/Assets.php
+++ b/app/Assets.php
@@ -93,17 +93,14 @@ class Assets {
 		}
 
 		if ( empty( $domain_name ) ) {
-			$domain_name='tickets.voordemensen.nl';
+			$domain_name = 'tickets.voordemensen.nl';
 		}
-
-
 
 		$display_type = ( new TicketSalesScreenTypeSetting() )->get_value();
-		$src          = 'https://' . rawurlencode ( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_loader.js';
-		if ( $display_type === 'side' ) {
-			$src = 'https://' . rawurlencode ( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_sideloader.js';
+		$src = 'https://' . rawurlencode($domain_name) . '/' . rawurlencode($client_name) . '/event/vdm_loader.js';
+		if ($display_type === 'side') {
+			$src = 'https://' . rawurlencode($domain_name) . '/' . rawurlencode($client_name) . '/event/vdm_sideloader.js';
 		}
-
 		wp_enqueue_script( 'll_vdm_external_script', $src, array(), LL_VDM_PLUGIN_VERSION, true );
 	}
 

--- a/app/Assets.php
+++ b/app/Assets.php
@@ -86,14 +86,9 @@ class Assets {
 
 	public function enqueue_external_vdm_script(): void {
 		$client_name = ( new ClientNameSetting() )->get_value();
-		$domain_name = ( new DomainNameSetting() )->get_value();
-
+		$domain_name = ( new DomainNameSetting() )->get_value() ?: 'tickets.voordemensen.nl';
 		if ( empty( $client_name ) ) {
 			return;
-		}
-
-		if ( empty( $domain_name ) ) {
-			$domain_name = 'tickets.voordemensen.nl';
 		}
 
 		$display_type = ( new TicketSalesScreenTypeSetting() )->get_value();

--- a/app/Assets.php
+++ b/app/Assets.php
@@ -97,9 +97,9 @@ class Assets {
 		}
 
 		$display_type = ( new TicketSalesScreenTypeSetting() )->get_value();
-		$src          = 'https://' . rawurlencode( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_loader.js';
+		$src          = 'https://' . $domain_name . '/' . $client_name . '/event/vdm_loader.js';
 		if ( $display_type === 'side' ) {
-			$src = 'https://' . rawurlencode( $domain_name ) . '/' . rawurlencode( $client_name ) . '/event/vdm_sideloader.js';
+			$src = 'https://' . $domain_name . '/' . $client_name . '/event/vdm_sideloader.js';
 		}
 		wp_enqueue_script( 'll_vdm_external_script', $src, array(), LL_VDM_PLUGIN_VERSION, true );
 	}


### PR DESCRIPTION
## Overview
We've introduced the capability for VoordeMensen clients to host their ticketing frontend on custom domains, such as tickets.mydomain.nl. This enhancement allows for a more branded and cohesive user experience.

### Implementation Details
To support this functionality, it's crucial that our loaders and session management scripts are correctly loaded from the URLs corresponding to the configured custom domains. For example, the loader script should be fetched from:

`https://tickets.mijnschouwburg.nl/mijnschouwburg/event/vdm_loader.js`

### Proposed Changes in Plugin Settings
A new settings field will be introduced within the LevelLevel plugin configuration to accommodate this feature. This field will allow users to specify their custom domain, which will be used to construct the URLs necessary for loading the frontend components.

### Usage
After updating the plugin settings with the custom domain, all frontend resources will be loaded from the specified domain, ensuring that all components function seamlessly under the new domain without compromising functionality or security.
This update requires careful configuration of both DNS settings and server hosting to ensure that domains are correctly pointing to the correct servers and that CORS policies are appropriately managed to allow resource sharing.